### PR TITLE
Temporary W/A for GitHub Action Tag release error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,9 @@ try:
 except:
     version = "unknown-rev"
 # The full version, including alpha/beta/rc tags
+# TEMP FIX: Hardcode the version here until Github resolves the Github Action Tag issue:
+# https://github.com/orgs/community/discussions/62991
+version = "v0.8"
 release = version
 
 


### PR DESCRIPTION
As mentioned in https://github.com/orgs/community/discussions/62991, hardcode the version in conf.py for now, as the Git Tag is causing the build error in GitHub action:
"Branch "x" is not allowed to deploy to github-pages due to environment protection rules."
Will remove this W/A after GitHub issues the proper fix.