### PR TITLE
Chapter 4: Add new compatible string for Reserved-memory Node

### DIFF
--- a/docs/chapter4-payload-handoff-format.rst
+++ b/docs/chapter4-payload-handoff-format.rst
@@ -1052,11 +1052,11 @@ skipped if unsupported by the platform.
                       by OS runtime services.
     runtime-data      Runtime service data memory region which will be used
                       by OS runtime services.
-    soft-reserve      Specific-purpose memory (SPM). The memory is earmarked
-                      for specific purposes such as for specific device
-                      drivers or applications.
+    special-purpose   Specific-purpose memory (e.g.: HBM or CXL). The memory
+                      is earmarked for specific purposes such as for specific
+                      device drivers or applications.
                       
-                      The SPM attribute serves as a hint to the OS to avoid
+                      This attribute serves as a hint to the OS to avoid
                       allocating this memory for core OS data or code that
                       can not be relocated. Prolonged use of this memory for
                       purposes other than the intended purpose may result in

--- a/docs/chapter4-payload-handoff-format.rst
+++ b/docs/chapter4-payload-handoff-format.rst
@@ -1052,6 +1052,15 @@ skipped if unsupported by the platform.
                       by OS runtime services.
     runtime-data      Runtime service data memory region which will be used
                       by OS runtime services.
+    soft-reserve      Specific-purpose memory (SPM). The memory is earmarked
+                      for specific purposes such as for specific device
+                      drivers or applications.
+                      
+                      The SPM attribute serves as a hint to the OS to avoid
+                      allocating this memory for core OS data or code that
+                      can not be relocated. Prolonged use of this memory for
+                      purposes other than the intended purpose may result in
+                      suboptimal platform performance.
     smbios            If Platform Init has created a SMBIOS data buffer, this
                       will have the SMBIOS data buffer region information.
                       SMBIOS 3.0 or above must be supported by payload.


### PR DESCRIPTION
Add soft-reserve: specific-purpose memory (SPM) as a new compatible string. The origin of this string is from UEFI spec: EFI_MEMORY_SP. This is used to mark a memory region for specific purposes such as for specific device drivers or applications.