### PR TITLE
Chapter 4: Add pixelsperscanline property for framebuffer node

### DIFF
--- a/docs/chapter4-payload-handoff-format.rst
+++ b/docs/chapter4-payload-handoff-format.rst
@@ -798,6 +798,7 @@ payload (in the case that only a single display output is supported by payload).
                                                     * `a8r8g8b8` - 32-bit pixels, d[31:24]=a, d[23:16]=r, d[15:8]=g, d[7:0]=b
                                                     * `a16b16g16r16` - 64-bit pixels, d[63:48]=a, d[47:32]=r, d[31:16]=g, d[15:0]=b
    display           R           string             Point to the PCI graphics device which provides this framebuffer as the primary display device.
+   pixelsperscanline R           u32                number of pixel elements per video memory line.
    ================= =========== ================== ======================================================================================================================================================================
 
 Example below shows how framebuffer node is generated:


### PR DESCRIPTION
pixelsperscanline defines the number of pixel elements per video memory line. For performance reasons, or due to hardware restrictions, scan lines may be padded to an amount of memory alignment. These padding pixel elements are outside the area covered by HorizontalResolution and are not visible.

For direct frame buffer access, this number is used as a span between starts of pixel lines in video memory. Based on the size of an individual pixel element and PixelsPerScanline , the offset in video memory from pixel element (x, y) to pixel element (x, y+1) has to be calculated as “sizeof( PixelElement ) * PixelsPerScanLine”,
not “sizeof( PixelElement ) * HorizontalResolution”, though in many cases those values can coincide.

This value can depend on video hardware and mode resolution. GOP implementation is responsible for providing accurate value for this field.